### PR TITLE
Remove "use strict" from extension

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,5 +1,3 @@
-"use strict";
-
 // The module 'vscode' contains the VS Code extensibility API
 // Import the module and reference it with the alias vscode in your code below
 import * as vscode from "vscode";


### PR DESCRIPTION
Fixes #723

`flow-parser` export is not compatible with strict mode.